### PR TITLE
Support access to parent AmbientProvider for deferred loading

### DIFF
--- a/src/Portable.Xaml/Portable.Xaml/ValueSerializerContext.cs
+++ b/src/Portable.Xaml/Portable.Xaml/ValueSerializerContext.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (C) 2010 Novell Inc. http://novell.com
 //
 // Permission is hereby granted, free of charge, to any person obtaining
@@ -43,13 +43,13 @@ namespace Portable.Xaml
 		NamespaceResolver namespace_resolver;
 		PrefixLookup prefix_lookup;
 		XamlSchemaContext sctx;
-		IAmbientProvider ambient_provider;
+		Func<IAmbientProvider> _ambientProviderProvider;
 		IProvideValueTarget provideValue;
 		IRootObjectProvider rootProvider;
 		IDestinationTypeProvider destinationProvider;
 		IXamlObjectWriterFactory objectWriterFactory;
 
-		public ValueSerializerContext(PrefixLookup prefixLookup, XamlSchemaContext schemaContext, IAmbientProvider ambientProvider, IProvideValueTarget provideValue, IRootObjectProvider rootProvider, IDestinationTypeProvider destinationProvider, IXamlObjectWriterFactory objectWriterFactory)
+		public ValueSerializerContext(PrefixLookup prefixLookup, XamlSchemaContext schemaContext, Func<IAmbientProvider> ambientProviderProvider, IProvideValueTarget provideValue, IRootObjectProvider rootProvider, IDestinationTypeProvider destinationProvider, IXamlObjectWriterFactory objectWriterFactory)
 		{
 			if (prefixLookup == null)
 				throw new ArgumentNullException("prefixLookup");
@@ -57,7 +57,7 @@ namespace Portable.Xaml
 				throw new ArgumentNullException("schemaContext");
 			prefix_lookup = prefixLookup;
 			sctx = schemaContext;
-			ambient_provider = ambientProvider;
+			_ambientProviderProvider = ambientProviderProvider;
 			this.provideValue = provideValue;
 			this.rootProvider = rootProvider;
 			this.destinationProvider = destinationProvider;
@@ -81,7 +81,7 @@ namespace Portable.Xaml
 			if (serviceType == typeof(IXamlTypeResolver))
 				return TypeResolver;
 			if (serviceType == typeof(IAmbientProvider))
-				return ambient_provider;
+				return _ambientProviderProvider?.Invoke();
 			if (serviceType == typeof(IXamlSchemaContextProvider))
 				return this;
 			if (serviceType == typeof(IProvideValueTarget))

--- a/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlObjectWriter.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (C) 2010 Novell Inc. http://novell.com
 // Copyright (C) 2012 Xamarin Inc. http://xamarin.com
 //
@@ -76,13 +76,18 @@ namespace Portable.Xaml
 		}
 
 		public XamlObjectWriter (XamlSchemaContext schemaContext, XamlObjectWriterSettings settings)
+			: this (schemaContext, settings, null)
+		{
+		}
+
+		public XamlObjectWriter(XamlSchemaContext schemaContext, XamlObjectWriterSettings settings, IAmbientProvider parentAmbientProvider)
 		{
 			if (schemaContext == null)
-				throw new ArgumentNullException ("schemaContext");
+				throw new ArgumentNullException("schemaContext");
 			this.sctx = schemaContext;
-			this.settings = settings ?? new XamlObjectWriterSettings ();
-			var manager = new XamlWriterStateManager<XamlObjectWriterException, XamlObjectWriterException> (false);
-			intl = new XamlObjectWriterInternal (this, sctx, manager);
+			this.settings = settings ?? new XamlObjectWriterSettings();
+			var manager = new XamlWriterStateManager<XamlObjectWriterException, XamlObjectWriterException>(false);
+			intl = new XamlObjectWriterInternal(this, sctx, manager, parentAmbientProvider);
 		}
 
 		XamlSchemaContext sctx;
@@ -283,13 +288,19 @@ namespace Portable.Xaml
 		const string Xmlns2000Namespace = "http://www.w3.org/2000/xmlns/";
 
 		public XamlObjectWriterInternal (XamlObjectWriter source, XamlSchemaContext schemaContext, XamlWriterStateManager manager)
-			: base (schemaContext, manager)
+			: this (source, schemaContext, manager, null)
+		{
+		}
+		public XamlObjectWriterInternal(
+			XamlObjectWriter source, XamlSchemaContext schemaContext,
+			XamlWriterStateManager manager, IAmbientProvider parentAmbientProvider)
+			: base(schemaContext, manager, parentAmbientProvider)
 		{
 			this.source = source;
 			var ext = source.Settings.ExternalNameScope;
-			name_scope = ext != null && source.Settings.RegisterNamesOnExternalNamescope ? ext : new NameScope (ext);
+			name_scope = ext != null && source.Settings.RegisterNamesOnExternalNamescope ? ext : new NameScope(ext);
 		}
-		
+
 		XamlObjectWriter source;
 		INameScope name_scope;
 		List<NameFixupRequired> pending_name_references = new List<NameFixupRequired> ();

--- a/src/Portable.Xaml/Portable.Xaml/XamlWriterInternalBase.cs
+++ b/src/Portable.Xaml/Portable.Xaml/XamlWriterInternalBase.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (C) 2010 Novell Inc. http://novell.com
 // Copyright (C) 2012 Xamarin Inc. http://xamarin.com
 //
@@ -41,14 +41,31 @@ namespace Mono.Xaml
 namespace Portable.Xaml
 #endif
 {
-	abstract class XamlWriterInternalBase : IProvideValueTarget, IRootObjectProvider, IDestinationTypeProvider, IAmbientProvider
+	abstract class XamlWriterInternalBase : IProvideValueTarget, IRootObjectProvider, IDestinationTypeProvider
 	{
 		protected XamlWriterInternalBase(XamlSchemaContext schemaContext, XamlWriterStateManager manager)
+			: this(schemaContext, manager, null)
 		{
+		}
+
+		protected XamlWriterInternalBase(XamlSchemaContext schemaContext, XamlWriterStateManager manager, IAmbientProvider parentAmbientProvider = null)
+		{
+			this.parentAmbientProvider = parentAmbientProvider;
 			this.sctx = schemaContext;
 			this.manager = manager;
 			var p = new PrefixLookup(sctx) { IsCollectingNamespaces = true }; // it does not raise unknown namespace error.
-			service_provider = new ValueSerializerContext(p, schemaContext, this, this, this, this, this as IXamlObjectWriterFactory);
+			service_provider = new ValueSerializerContext(p, schemaContext, GetCurrentAmbientProvider, this, this, this, this as IXamlObjectWriterFactory);
+		}
+
+
+
+		protected virtual IAmbientProvider GetCurrentAmbientProvider()
+		{
+			IAmbientProvider basicAmbientProvider = new ObjectStatesAmbientProvider(object_states);
+			var ambientProvider =
+				parentAmbientProvider == null ? basicAmbientProvider
+					: new StackAmbientProvider(basicAmbientProvider, parentAmbientProvider);
+			return ambientProvider;
 		}
 
 		internal XamlSchemaContext sctx;
@@ -57,14 +74,13 @@ namespace Portable.Xaml
 		internal ValueSerializerContext service_provider;
 
 		internal ObjectState root_state;
-		internal Stack<ObjectState> object_states = new Stack<ObjectState>();
+		internal readonly Stack<ObjectState> object_states = new Stack<ObjectState>();
+		internal readonly IAmbientProvider parentAmbientProvider;
 		internal PrefixLookup prefix_lookup => (PrefixLookup)service_provider.GetService(typeof(INamespacePrefixLookup));
 
 		public Type GetDestinationType() => CurrentMember?.Type.UnderlyingType;
 
 		List<NamespaceDeclaration> Namespaces => prefix_lookup.Namespaces;
-
-		internal virtual IAmbientProvider AmbientProvider => null;
 
 		internal class ObjectState
 		{
@@ -299,66 +315,109 @@ namespace Portable.Xaml
 				throw new XamlXmlWriterException(String.Format("Value type is '{0}' but it must be either string or any type that is convertible to string indicated by TypeConverterAttribute.", value != null ? value.GetType() : null));
 		}
 
-		#region IAmbientProvider
+		private class ObjectStatesAmbientProvider : IAmbientProvider
+		{
+			public ObjectStatesAmbientProvider(IEnumerable<ObjectState> objectStates)
+			{
+				object_states = objectStates.ToArray();
+			}
+
+			private IReadOnlyCollection<ObjectState> object_states { get; }
+
+			public IEnumerable<object> GetAllAmbientValues(params XamlType[] types)
+			{
+				return GetAllAmbientValues(null, false, types).Select(r => r.Value);
+			}
+
+			public IEnumerable<AmbientPropertyValue> GetAllAmbientValues(IEnumerable<XamlType> ceilingTypes, params XamlMember[] properties)
+			{
+				return GetAllAmbientValues(ceilingTypes, false, null, properties);
+			}
+
+			public IEnumerable<AmbientPropertyValue> GetAllAmbientValues(IEnumerable<XamlType> ceilingTypes, bool searchLiveStackOnly, IEnumerable<XamlType> types, params XamlMember[] properties)
+			{
+				// check arguments
+				if (properties == null)
+					throw new ArgumentNullException("properties");
+
+				var nonAmbientProperty = properties.FirstOrDefault(r => !r.IsAmbient);
+				if (nonAmbientProperty != null)
+					throw new ArgumentException(nonAmbientProperty.ToString() + "is not an ambient property", "properties");
+
+				return DoGetAllAmbientValues(ceilingTypes, searchLiveStackOnly, types, properties);
+			}
+
+			private IEnumerable<AmbientPropertyValue> DoGetAllAmbientValues(IEnumerable<XamlType> ceilingTypes, bool searchLiveStackOnly, IEnumerable<XamlType> types, params XamlMember[] properties)
+			{
+				foreach (var state in object_states)
+				{
+					if (ceilingTypes != null && ceilingTypes.Contains(state.Type))
+						yield break;
+
+					if (types != null)
+					{
+						if (types.Any(xt => xt.UnderlyingType != null && xt.CanAssignFrom(state.Type)))
+							yield return new AmbientPropertyValue(null, state.Value);
+					}
+					if (properties != null)
+					{
+						// get ambient properties in the stack
+						foreach (var prop in properties)
+						{
+							if (!prop.DeclaringType.CanAssignFrom(state.Type))
+								continue;
+							var value = prop.Invoker.GetValue(state.Value);
+							yield return new AmbientPropertyValue(prop, value);
+						}
+					}
+				}
+			}
+
+			public object GetFirstAmbientValue(params XamlType[] types)
+			{
+				return GetAllAmbientValues(types).FirstOrDefault();
+			}
+
+			public AmbientPropertyValue GetFirstAmbientValue(IEnumerable<XamlType> ceilingTypes, params XamlMember[] properties)
+			{
+				return GetAllAmbientValues(ceilingTypes, properties).FirstOrDefault();
+			}
+		}
+	}
+
+	internal class StackAmbientProvider : IAmbientProvider
+	{
+		public StackAmbientProvider(params IAmbientProvider[] providers)
+		{
+			Providers = providers;
+		}
+
+		private IAmbientProvider[] Providers { get; }
 
 		public IEnumerable<object> GetAllAmbientValues(params XamlType[] types)
 		{
-			return GetAllAmbientValues(null, false, types).Select(r => r.Value);
+			return Providers.SelectMany(x => x.GetAllAmbientValues(types));
 		}
 
 		public IEnumerable<AmbientPropertyValue> GetAllAmbientValues(IEnumerable<XamlType> ceilingTypes, params XamlMember[] properties)
 		{
-			return GetAllAmbientValues(ceilingTypes, false, null, properties);
+			return Providers.SelectMany(x => x.GetAllAmbientValues(ceilingTypes, properties));
 		}
 
-		public IEnumerable<AmbientPropertyValue> GetAllAmbientValues(IEnumerable<XamlType> ceilingTypes, bool searchLiveStackOnly, IEnumerable<XamlType> types, params XamlMember[] properties)
+		public IEnumerable<AmbientPropertyValue> GetAllAmbientValues(IEnumerable<XamlType> ceilingTypes, bool searchLiveStackOnly, IEnumerable<XamlType> types,
+			params XamlMember[] properties)
 		{
-			// check arguments
-			if (properties == null)
-				throw new ArgumentNullException("properties");
-
-			var nonAmbientProperty = properties.FirstOrDefault(r => !r.IsAmbient);
-			if (nonAmbientProperty != null)
-				throw new ArgumentException(nonAmbientProperty.ToString() + "is not an ambient property", "properties");
-
-			return DoGetAllAmbientValues(ceilingTypes, searchLiveStackOnly, types, properties);
-		}
-
-		private IEnumerable<AmbientPropertyValue> DoGetAllAmbientValues(IEnumerable<XamlType> ceilingTypes, bool searchLiveStackOnly, IEnumerable<XamlType> types, params XamlMember[] properties)
-		{
-			foreach (var state in object_states)
-			{
-				if (ceilingTypes != null && ceilingTypes.Contains(state.Type))
-					yield break;
-
-				if (types != null)
-				{
-					if (types.Any(xt => xt.UnderlyingType != null && xt.CanAssignFrom(state.Type)))
-						yield return new AmbientPropertyValue(null, state.Value);
-				}
-				if (properties != null)
-				{
-					// get ambient properties in the stack
-					foreach (var prop in properties)
-					{
-						if (!prop.DeclaringType.CanAssignFrom(state.Type))
-							continue;
-						var value = prop.Invoker.GetValue(state.Value);
-						yield return new AmbientPropertyValue(prop, value);
-					}
-				}
-			}
+			return Providers.SelectMany(x => x.GetAllAmbientValues(ceilingTypes, searchLiveStackOnly, types, properties));
 		}
 
 		public object GetFirstAmbientValue(params XamlType[] types)
 		{
-			return GetAllAmbientValues(types).FirstOrDefault();
+			return Providers.SelectMany(x => x.GetAllAmbientValues(types)).FirstOrDefault();
 		}
 
 		public AmbientPropertyValue GetFirstAmbientValue(IEnumerable<XamlType> ceilingTypes, params XamlMember[] properties)
 		{
-			return GetAllAmbientValues(ceilingTypes, properties).FirstOrDefault();
+			return Providers.SelectMany(x => x.GetAllAmbientValues(ceilingTypes, properties)).FirstOrDefault();
 		}
-		#endregion
 	}
 }


### PR DESCRIPTION
The gist of this change is to enable passing in a parent AmbientProvider so that a child like DataTemplate can access Resources declared higher in hierarchy.

See PR https://github.com/AvaloniaUI/Avalonia/pull/1513

I'm not exactly sure how to make both PRs connected (working as submodule), so I may need help with that.